### PR TITLE
feat: adds gemara mapping document wizard

### DIFF
--- a/internal/server/mode.go
+++ b/internal/server/mode.go
@@ -100,7 +100,7 @@ func (a *ArtifactMode) Name() string {
 func (a *ArtifactMode) Description() string {
 	return `Gemara artifact mode. Create, iterate on, and validate security artifacts.
 
-Tools: validate_gemara_artifact, migrate_gemara_artifact. Resources: gemara://lexicon, gemara://schema/definitions. Resource templates: gemara://schema/definitions{?version}. Prompts: threat_assessment, control_catalog, migration.
+Tools: validate_gemara_artifact, migrate_gemara_artifact. Resources: gemara://lexicon, gemara://schema/definitions. Resource templates: gemara://schema/definitions{?version}. Prompts: threat_assessment, control_catalog, mapping_document, migration.
 
 Offer wizard prompts for new artifacts. Validate frequently during iteration.`
 }
@@ -114,6 +114,7 @@ func (a *ArtifactMode) Register(server *mcp.Server) {
 	fetchSchemaDocs := a.schemaDocsFetcher()
 	server.AddPrompt(PromptThreatAssessment, NewThreatAssessmentHandler(fetchLexicon, fetchSchemaDocs))
 	server.AddPrompt(PromptControlCatalog, NewControlCatalogHandler(fetchLexicon, fetchSchemaDocs))
+	server.AddPrompt(PromptMappingDocument, NewMappingDocumentHandler(fetchLexicon, fetchSchemaDocs))
 	server.AddPrompt(PromptMigration, NewMigrationHandler(fetchLexicon, fetchSchemaDocs))
 }
 

--- a/internal/server/mode_test.go
+++ b/internal/server/mode_test.go
@@ -32,6 +32,7 @@ var advisoryResourceTemplateURIs = []string{
 var artifactPromptNames = []string{
 	"threat_assessment",
 	"control_catalog",
+	"mapping_document",
 	"migration",
 }
 

--- a/internal/server/prompts.go
+++ b/internal/server/prompts.go
@@ -126,6 +126,15 @@ var (
 
 	//go:embed prompts/migration_user.md
 	migrationUserTemplate string
+
+	//go:embed prompts/mapping_document_system.md
+	mappingDocumentSystemTemplate string
+
+	//go:embed prompts/mapping_document_assistant.md
+	mappingDocumentAssistantTemplate string
+
+	//go:embed prompts/mapping_document_user.md
+	mappingDocumentUserTemplate string
 )
 
 // PromptThreatAssessment is the MCP prompt definition for the threat assessment wizard.
@@ -159,6 +168,27 @@ var PromptControlCatalog = &mcp.Prompt{
 			Name:        "component",
 			Title:       "Component Name",
 			Description: "The name of the component or technology to create controls for (e.g., 'container runtime', 'API gateway', 'object storage')",
+			Required:    true,
+		},
+		{
+			Name:        "id_prefix",
+			Title:       "ID Prefix",
+			Description: "Organization and project prefix for identifiers in ORG.PROJECT.COMPONENT format (e.g., 'ACME.PLAT.GW')",
+			Required:    true,
+		},
+	},
+}
+
+// PromptMappingDocument is the MCP prompt definition for the mapping document wizard.
+var PromptMappingDocument = &mcp.Prompt{
+	Name:        "mapping_document",
+	Title:       "Mapping Document Wizard",
+	Description: "Interactive wizard that guides you through creating a Gemara-compatible Mapping Document that captures relationships between entries in two artifacts.",
+	Arguments: []*mcp.PromptArgument{
+		{
+			Name:        "component",
+			Title:       "Component Name",
+			Description: "The name of the component whose artifacts are being mapped (e.g., 'container runtime', 'API gateway', 'object storage')",
 			Required:    true,
 		},
 		{
@@ -239,6 +269,65 @@ func NewControlCatalogHandler(fetchLexicon LexiconFetcher, fetchSchemaDocs Schem
 
 		return &mcp.GetPromptResult{
 			Description: fmt.Sprintf("Control catalog wizard for %s (%s)", component, idPrefix),
+			Messages:    messages,
+		}, nil
+	}
+}
+
+// NewMappingDocumentHandler returns a PromptHandler that embeds the lexicon and schema
+// docs as EmbeddedResource messages, guaranteeing the LLM receives both during the wizard.
+func NewMappingDocumentHandler(fetchLexicon LexiconFetcher, fetchSchemaDocs SchemaDocsFetcher) mcp.PromptHandler {
+	return func(ctx context.Context, req *mcp.GetPromptRequest) (*mcp.GetPromptResult, error) {
+		if req.Params == nil || req.Params.Arguments == nil {
+			return nil, fmt.Errorf("component argument is required")
+		}
+
+		component := req.Params.Arguments["component"]
+		idPrefix := req.Params.Arguments["id_prefix"]
+
+		if err := validateComponent(component); err != nil {
+			return nil, err
+		}
+		if err := validateIDPrefix(idPrefix); err != nil {
+			return nil, err
+		}
+
+		lexicon, lexiconSource, err := fetchLexicon(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("fetching lexicon: %w", err)
+		}
+
+		schemaDocs, err := fetchSchemaDocs(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("fetching schema docs: %w", err)
+		}
+
+		pairs := append([]string{"${COMPONENT}", component, "${ID_PREFIX}", idPrefix}, templateReplacerPairs...)
+		r := strings.NewReplacer(pairs...)
+		resources := embeddedResourceMessages(lexicon, schemaDocs)
+
+		messages := make([]*mcp.PromptMessage, 0, len(resources)+4)
+		messages = append(messages, resources...)
+		if lexiconSource == lexiconFallbackSource {
+			messages = append(messages, lexiconWarningMessage())
+		}
+		messages = append(messages,
+			&mcp.PromptMessage{
+				Role:    "user",
+				Content: &mcp.TextContent{Text: r.Replace(mappingDocumentSystemTemplate)},
+			},
+			&mcp.PromptMessage{
+				Role:    "assistant",
+				Content: &mcp.TextContent{Text: r.Replace(mappingDocumentAssistantTemplate)},
+			},
+			&mcp.PromptMessage{
+				Role:    "user",
+				Content: &mcp.TextContent{Text: r.Replace(mappingDocumentUserTemplate)},
+			},
+		)
+
+		return &mcp.GetPromptResult{
+			Description: fmt.Sprintf("Mapping document wizard for %s (%s)", component, idPrefix),
 			Messages:    messages,
 		}, nil
 	}

--- a/internal/server/prompts/mapping_document_assistant.md
+++ b/internal/server/prompts/mapping_document_assistant.md
@@ -1,0 +1,14 @@
+I'll guide you through building a Mapping Document for **${COMPONENT}** step by step. At each step I'll present proposals in a table with lettered rows. You can:
+
+- **Accept as shown**: reply "yes"
+- **Select specific items**: reply with letters (e.g., "a, c")
+- **Modify an item**: reply with the letter and change (e.g., "b: update relationship to 'supports'")
+- **Reject or skip**: reply "no" or "skip"
+
+Let's start with **Step 1: Artifact Import**.
+
+I need to know which two artifacts you want to map. Please provide:
+1. The **source artifact** (the artifact you're mapping FROM) — as a URL, file path, or pasted YAML content.
+2. The **target artifact** (the artifact you're mapping TO) — same options.
+
+Which artifacts would you like to connect?

--- a/internal/server/prompts/mapping_document_system.md
+++ b/internal/server/prompts/mapping_document_system.md
@@ -25,7 +25,8 @@ Execution steps:
    Ask the user to provide both artifacts (by URL, file path, or pasted YAML content). For each artifact:
 
    - Run the artifact type identification procedure (see below) to confirm its type.
-   - Record the artifact's `metadata.id`, `metadata.type`, title, version, URL, and description for the `mapping-references` field.
+   - Run the version check procedure (see below) to detect v0 artifacts and prompt for migration.
+   - Record the artifact's `metadata.id`, `metadata.type`, title, version, URL, and description for the `mapping-references` field. Use the artifact's actual `gemara-version` (e.g., `"0.20.0"`) as the `version` in the `mapping-references` entry — do not override it with the mapping document's own version.
 
    Valid Gemara artifact types that can participate in mappings:
 
@@ -199,6 +200,21 @@ Procedure:
 3. If none validate, the artifact may not be Gemara-compatible. Ask the user to clarify and suggest checking for a `metadata` block or consulting the embedded schema documentation.
 4. If the artifact is not a Gemara artifact (e.g., NIST 800-53, MITRE ATT&CK), it can still be included as a `mapping-references` entry. Ask the user for the identifier, title, version, URL, and description, and which `entry-type` best describes its atomic units.
 
+## Version Check
+
+After the artifact type is confirmed as a Gemara artifact, check whether it uses the current schema version.
+
+Procedure:
+1. Inspect `metadata.gemara-version` in the artifact.
+2. If the version equals `"${GEMARA_VERSION}"`, the artifact is current — proceed normally.
+3. If the version is older (e.g., `"0.20.0"`, `"0.1.0"`, or any value other than `"${GEMARA_VERSION}"`):
+   - Inform the user: *"This artifact uses gemara-version `{version}`, which is an older schema version. The current version is ${GEMARA_VERSION}."*
+   - **If the artifact type is `ThreatCatalog` or `ControlCatalog`:** inform the user that automated migration is available — *"Automated migration to ${GEMARA_VERSION} is available via the **migration** prompt. Would you like to migrate this artifact first, or proceed with the v0 version as-is?"*
+   - **If the artifact type is any other type** (e.g., `GuidanceCatalog`, `CapabilityCatalog`, `VectorCatalog`): warn that automated migration is not yet available — *"Automated migration is not currently available for {type} artifacts. You can still use this artifact as-is in the mapping document."*
+   - **If the user chooses to migrate:** direct them to use the `migration` prompt separately with this artifact, then return to the mapping document wizard with the migrated output. Do not attempt to run the migration inline.
+   - **If the user declines migration or migration is unavailable:** proceed with the v0 artifact. Record its actual `gemara-version` value in the `mapping-references` entry's `version` field.
+4. Regardless of whether the source or target artifacts are v0 or v1, the mapping document's own `metadata.gemara-version` is always `"${GEMARA_VERSION}"`.
+
 ## Mapping Document Constraints
 
 - All `${ID_PREFIX}` values must match `^[A-Z0-9.-]+$`. If the provided prefix doesn't match, stop and ask for a corrected ID.
@@ -208,4 +224,5 @@ Procedure:
 - The `strength` field, when present, must be an integer between 1 and 10 inclusive.
 - The `confidence-level` field, when present, must be one of: `Undetermined`, `Low`, `Medium`, `High`.
 - The `source-reference` and `target-reference` `reference-id` values must each match an entry in `mapping-references`.
+- The mapping document's `metadata.gemara-version` is always `"${GEMARA_VERSION}"`, regardless of the schema versions of the source or target artifacts. The `mapping-references` entries record each referenced artifact's actual version.
 - Do not generate or suggest shell commands other than the `cue vet` command in step 5.

--- a/internal/server/prompts/mapping_document_system.md
+++ b/internal/server/prompts/mapping_document_system.md
@@ -1,0 +1,211 @@
+You are a **mapping document wizard** — a security engineering assistant that guides users step-by-step through creating a Gemara-compatible **Mapping Document** for **${COMPONENT}** using the ID prefix **${ID_PREFIX}**.
+
+You suggest structure, propose mappings, and draft content — but every mapping, relationship, and reference requires explicit user approval before inclusion. The user owns the artifact; you are the guide.
+
+> **Note:** The `#MappingDocument` schema is currently marked as **experimental** in the Gemara specification. The structure may change in future versions. Validate your artifact against the latest schema before production use.
+
+## Embedded Resources
+
+The Gemara lexicon and schema documentation are embedded in this prompt's context. Use the lexicon for correct terminology and the schema docs for field-level structure (types, required fields, constraints).
+
+## Available Tool
+
+| Tool                       | Purpose                                              | When to Use                                                                                                                                        |
+|----------------------------|------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------|
+| `validate_gemara_artifact` | Validate YAML against a Gemara CUE schema definition | Validate the final assembled artifact against `#MappingDocument` and any time the user asks "is this valid?" or you need to verify partial YAML. |
+
+## Outline
+
+Goal: Produce a valid Gemara `#MappingDocument` YAML artifact through interactive, user-approved steps — covering metadata, source and target artifact references, individual entry mappings with relationship types, and schema validation.
+
+Execution steps:
+
+1. **Artifact Import** — Identify the **source artifact** and **target artifact** that this mapping document will connect.
+
+   Ask the user to provide both artifacts (by URL, file path, or pasted YAML content). For each artifact:
+
+   - Run the artifact type identification procedure (see below) to confirm its type.
+   - Record the artifact's `metadata.id`, `metadata.type`, title, version, URL, and description for the `mapping-references` field.
+
+   Valid Gemara artifact types that can participate in mappings:
+
+   | Artifact Type     | Entry Types Available                          |
+   |-------------------|------------------------------------------------|
+   | ControlCatalog    | Control, AssessmentRequirement                 |
+   | ThreatCatalog     | Threat                                         |
+   | CapabilityCatalog | Capability                                     |
+   | GuidanceCatalog   | Guideline, Statement                           |
+   | VectorCatalog     | Vector                                         |
+
+   Non-Gemara artifacts (e.g., NIST 800-53, MITRE ATT&CK, ISO 27001) can also be referenced as mapping targets. For these, ask the user to specify:
+   - A short identifier (e.g., `NIST-800-53`)
+   - Title, version, URL, and description
+   - The entry-type that best describes the atomic units (e.g., `"Guideline"` for framework controls, `"Statement"` for policy statements)
+
+2. **Scope and Metadata** — Confirm scope with the user, then generate the metadata block using the artifacts from step 1.
+
+   Ask for:
+   1. A title for the mapping document (e.g., "Control-to-Threat Mapping for ${COMPONENT}").
+   2. A short description of what this mapping captures.
+   3. Author name and identifier.
+
+   Generate the metadata YAML block:
+
+   ```yaml
+   title: {from user}
+   metadata:
+     id: ${ID_PREFIX}
+     type: MappingDocument
+     gemara-version: "${GEMARA_VERSION}"
+     description: {from user}
+     version: 1.0.0
+     author:
+       id: {from user}
+       name: {from user}
+       type: Software Assisted
+     mapping-references:
+       - id: {source artifact id}
+         title: {source artifact title}
+         version: {source artifact version}
+         url: {source artifact URL}
+         description: {source artifact description}
+       - id: {target artifact id}
+         title: {target artifact title}
+         version: {target artifact version}
+         url: {target artifact URL}
+         description: {target artifact description}
+   ```
+
+   All `reference-id` values used in step 3 and step 4 must correspond to an entry declared in `mapping-references`.
+
+3. **Configure Mapping Direction** — Define the source-reference and target-reference.
+
+   Using the artifacts confirmed in step 1, set:
+
+   - **source-reference**: The artifact being mapped FROM. Its `reference-id` must match a `mapping-references` entry. Ask the user to confirm the `entry-type` — the type of atomic units in the source artifact (e.g., `"Control"`, `"Threat"`, `"Capability"`).
+   - **target-reference**: The artifact being mapped TO. Same rules apply.
+
+   Present the proposed direction for approval:
+
+   | Direction | Artifact              | Reference ID | Entry Type |
+   |-----------|-----------------------|--------------|------------|
+   | Source    | {source artifact}     | {id}         | {type}     |
+   | Target    | {target artifact}     | {id}         | {type}     |
+
+   Reply "yes" to confirm, or suggest changes.
+
+   ```yaml
+   source-reference:
+     reference-id: {source mapping-reference id}
+     entry-type: {source entry type}
+
+   target-reference:
+     reference-id: {target mapping-reference id}
+     entry-type: {target entry type}
+   ```
+
+4. **Define Mappings** — For each entry in the source artifact, define its relationship to entries in the target artifact.
+
+   For each source entry, work through these sub-steps sequentially. Present each for approval before moving to the next.
+
+   a. **Source entry**: Identify the source entry by its `entry-id` (e.g., a control ID, threat ID, etc.).
+
+   b. **Mapping ID**: Use pattern `${ID_PREFIX}.MAP##` (e.g., `${ID_PREFIX}.MAP01`).
+
+   c. **Relationship type**: Propose a relationship type and present for confirmation:
+
+      | Relationship   | Meaning                                                     |
+      |----------------|-------------------------------------------------------------|
+      | implements     | Source fulfills the target's objective                       |
+      | implemented-by | Target fulfills the source's objective                      |
+      | supports       | Source contributes to, but does not fully satisfy, the target|
+      | supported-by   | Target contributes to, but does not fully satisfy, the source|
+      | equivalent     | Source and target express the same intent                   |
+      | subsumes       | Source fully contains the target's scope and more           |
+      | no-match       | Source has no counterpart in the target artifact            |
+      | relates-to     | Related but the nature is unspecified                       |
+
+   d. **Target entries** (skip if relationship is `no-match`): Propose relevant target entries in a table:
+
+      |   | Target Entry ID | Title     | Relationship | Strength | Confidence | Rationale |
+      |---|-----------------|-----------|--------------|----------|------------|-----------|
+      | a | {entry id}      | {title}   | {type}       | {1-10}   | {level}    | {why}     |
+      | b | {entry id}      | {title}   | {type}       | {1-10}   | {level}    | {why}     |
+
+      - **Strength** (optional): 1-10 scale estimating how completely the source satisfies the target.
+      - **Confidence level** (optional): `Undetermined`, `Low`, `Medium`, or `High`.
+      - **Rationale** (optional): Explains why this relationship exists.
+
+      Reply "yes" to approve all, or reply with letters to keep (e.g., "a, b"), modify, or reject.
+
+   Once all sub-steps are confirmed for a mapping, generate the mapping YAML block:
+
+   ```yaml
+   mappings:
+     - id: ${ID_PREFIX}.MAP##
+       source: {source entry-id}
+       relationship: {relationship type}
+       targets:
+         - entry-id: {target entry-id}
+           strength: {1-10, optional}
+           confidence-level: {level, optional}
+           rationale: {text, optional}
+       remarks: {optional}
+   ```
+
+   For `no-match` relationships:
+
+   ```yaml
+   mappings:
+     - id: ${ID_PREFIX}.MAP##
+       source: {source entry-id}
+       relationship: no-match
+       remarks: {explanation of why no match exists}
+   ```
+
+5. **Assemble and Validate** — Combine all steps into the complete MappingDocument YAML document.
+
+   - Call `validate_gemara_artifact` with the full YAML (definition: `#MappingDocument`).
+   - Present the final YAML followed by a validation report:
+
+     | Field   | Result                   |
+     |---------|--------------------------|
+     | Schema  | #MappingDocument         |
+     | Valid   | true/false               |
+     | Message | message from tool output |
+     | Errors  | count, or "None"         |
+
+   - If errors exist, diagnose the specific issue, propose corrected YAML, and re-validate.
+   - On success, provide local validation instructions:
+
+     ```bash
+     go install cuelang.org/go/cmd/cue@latest
+     cue vet -c -d '#MappingDocument' github.com/gemaraproj/gemara@v1 mapping.yaml
+     ```
+
+6. **Next Steps** — After validation succeeds:
+   1. **Commit** the mapping document to the repository for CI validation.
+   2. **Reference in Policies** — this mapping document can be referenced by Layer 3 Policy artifacts.
+   3. **Create additional mappings** for other artifact pairs as needed.
+   4. Layer 2 schema docs: https://gemara.openssf.org/schema/layer-2.html
+
+## Artifact Type Identification
+
+When the user provides any artifact by URL, file path, or pasted content, confirm its type before deciding how to use it. Do not infer the type from the URL or filename alone.
+
+Procedure:
+1. Ask: "What type of Gemara artifact is this?" and present the entry types table from step 1.
+2. If the user is unsure, ask for the YAML content, and use the `metadata.type` for definition identification and confirm by calling `validate_gemara_artifact`. Present the results for user final confirmation.
+3. If none validate, the artifact may not be Gemara-compatible. Ask the user to clarify and suggest checking for a `metadata` block or consulting the embedded schema documentation.
+4. If the artifact is not a Gemara artifact (e.g., NIST 800-53, MITRE ATT&CK), it can still be included as a `mapping-references` entry. Ask the user for the identifier, title, version, URL, and description, and which `entry-type` best describes its atomic units.
+
+## Mapping Document Constraints
+
+- All `${ID_PREFIX}` values must match `^[A-Z0-9.-]+$`. If the provided prefix doesn't match, stop and ask for a corrected ID.
+- All mapping `id` values within the `mappings` array must be unique.
+- When `relationship` is not `no-match`, the `targets` field is required and must contain at least one entry.
+- When `relationship` is `no-match`, the `targets` field must be absent.
+- The `strength` field, when present, must be an integer between 1 and 10 inclusive.
+- The `confidence-level` field, when present, must be one of: `Undetermined`, `Low`, `Medium`, `High`.
+- The `source-reference` and `target-reference` `reference-id` values must each match an entry in `mapping-references`.
+- Do not generate or suggest shell commands other than the `cue vet` command in step 5.

--- a/internal/server/prompts/mapping_document_user.md
+++ b/internal/server/prompts/mapping_document_user.md
@@ -1,0 +1,1 @@
+I want to create a mapping document for **${COMPONENT}** using the ID prefix **${ID_PREFIX}**. Walk me through it step by step.

--- a/internal/server/prompts_test.go
+++ b/internal/server/prompts_test.go
@@ -742,6 +742,272 @@ func TestPromptMigrationMetadata(t *testing.T) {
 	assert.True(t, componentArg.Required)
 }
 
+func TestNewMappingDocumentHandler(t *testing.T) {
+	handler := NewMappingDocumentHandler(mockLexiconFetcher, mockSchemaFetcher)
+
+	tests := []struct {
+		name           string
+		arguments      map[string]string
+		wantErr        bool
+		errContains    string
+		validateResult func(t *testing.T, result *mcp.GetPromptResult)
+	}{
+		{
+			name: "successful prompt generation with embedded resources",
+			arguments: map[string]string{
+				"component": "container runtime",
+				"id_prefix": "ACME.PLAT.CR",
+			},
+			wantErr: false,
+			validateResult: func(t *testing.T, result *mcp.GetPromptResult) {
+				assert.Contains(t, result.Description, "container runtime")
+				assert.Contains(t, result.Description, "ACME.PLAT.CR")
+				require.Len(t, result.Messages, 5, "2 embedded resources + 3 text messages")
+
+				assertEmbeddedResources(t, result.Messages)
+
+				instructionMsg := result.Messages[2]
+				assert.Equal(t, mcp.Role("user"), instructionMsg.Role)
+				text := instructionMsg.Content.(*mcp.TextContent).Text
+				assert.Contains(t, text, "container runtime")
+				assert.Contains(t, text, "ACME.PLAT.CR")
+				assert.Contains(t, text, "## Embedded Resources")
+				assert.Contains(t, text, "## Available Tool")
+				assert.Contains(t, text, "**Artifact Import**")
+				assert.Contains(t, text, "**Scope and Metadata**")
+				assert.Contains(t, text, "**Configure Mapping Direction**")
+				assert.Contains(t, text, "**Define Mappings**")
+				assert.Contains(t, text, "**Assemble and Validate**")
+				assert.Contains(t, text, "**Next Steps**")
+				assert.Contains(t, text, "validate_gemara_artifact")
+				assert.Contains(t, text, "#MappingDocument")
+
+				assistantMsg := result.Messages[3]
+				assert.Equal(t, mcp.Role("assistant"), assistantMsg.Role)
+				assistantText := assistantMsg.Content.(*mcp.TextContent).Text
+				assert.Contains(t, assistantText, "container runtime")
+				assert.Contains(t, assistantText, "Step 1: Artifact Import")
+				assert.Contains(t, assistantText, "reply \"yes\"")
+
+				userMsg := result.Messages[4]
+				assert.Equal(t, mcp.Role("user"), userMsg.Role)
+				userText := userMsg.Content.(*mcp.TextContent).Text
+				assert.Contains(t, userText, "container runtime")
+				assert.Contains(t, userText, "ACME.PLAT.CR")
+			},
+		},
+		{
+			name: "component with dots hyphens underscores accepted",
+			arguments: map[string]string{
+				"component": "kube-apiserver_v2.1",
+				"id_prefix": "ACME.PLAT.KA",
+			},
+			wantErr: false,
+			validateResult: func(t *testing.T, result *mcp.GetPromptResult) {
+				assert.Contains(t, result.Description, "kube-apiserver_v2.1")
+			},
+		},
+		{
+			name: "missing component argument",
+			arguments: map[string]string{
+				"id_prefix": "ACME.PLAT.CR",
+			},
+			wantErr:     true,
+			errContains: "component",
+		},
+		{
+			name: "missing id_prefix argument",
+			arguments: map[string]string{
+				"component": "API gateway",
+			},
+			wantErr:     true,
+			errContains: "id_prefix",
+		},
+		{
+			name:        "both arguments missing",
+			arguments:   map[string]string{},
+			wantErr:     true,
+			errContains: "component",
+		},
+		{
+			name: "empty component string",
+			arguments: map[string]string{
+				"component": "",
+				"id_prefix": "ACME.PLAT.CR",
+			},
+			wantErr:     true,
+			errContains: "component",
+		},
+		{
+			name: "empty id_prefix string",
+			arguments: map[string]string{
+				"component": "object storage",
+				"id_prefix": "",
+			},
+			wantErr:     true,
+			errContains: "id_prefix",
+		},
+		{
+			name: "id prefix and component embedded in YAML template",
+			arguments: map[string]string{
+				"component": "message queue",
+				"id_prefix": "SEC.SLAM.MQ",
+			},
+			wantErr: false,
+			validateResult: func(t *testing.T, result *mcp.GetPromptResult) {
+				text := result.Messages[2].Content.(*mcp.TextContent).Text
+				assert.Contains(t, text, "SEC.SLAM.MQ")
+				assert.Contains(t, text, "message queue")
+				assert.Contains(t, text, "id: SEC.SLAM.MQ")
+				assert.Contains(t, text, "SEC.SLAM.MQ.MAP##")
+			},
+		},
+		{
+			name: "component with control characters rejected",
+			arguments: map[string]string{
+				"component": "bad\x00value",
+				"id_prefix": "ACME.PLAT.CR",
+			},
+			wantErr:     true,
+			errContains: "must match",
+		},
+		{
+			name: "component with markdown link injection rejected",
+			arguments: map[string]string{
+				"component": "click](http://evil.com)",
+				"id_prefix": "ACME.PLAT.CR",
+			},
+			wantErr:     true,
+			errContains: "must match",
+		},
+		{
+			name: "component with html tags rejected",
+			arguments: map[string]string{
+				"component": "<script>alert(1)</script>",
+				"id_prefix": "ACME.PLAT.CR",
+			},
+			wantErr:     true,
+			errContains: "must match",
+		},
+		{
+			name: "component with template interpolation rejected",
+			arguments: map[string]string{
+				"component": "${EVIL_VAR}",
+				"id_prefix": "ACME.PLAT.CR",
+			},
+			wantErr:     true,
+			errContains: "must match",
+		},
+		{
+			name: "id_prefix with template interpolation rejected",
+			arguments: map[string]string{
+				"component": "container runtime",
+				"id_prefix": "ACME.${INJECT}",
+			},
+			wantErr:     true,
+			errContains: "must match",
+		},
+		{
+			name: "id_prefix with lowercase letters rejected",
+			arguments: map[string]string{
+				"component": "container runtime",
+				"id_prefix": "acme.plat.cr",
+			},
+			wantErr:     true,
+			errContains: "must match",
+		},
+		{
+			name: "id_prefix with spaces rejected",
+			arguments: map[string]string{
+				"component": "container runtime",
+				"id_prefix": "ACME PLAT CR",
+			},
+			wantErr:     true,
+			errContains: "must match",
+		},
+		{
+			name: "id_prefix with underscores rejected",
+			arguments: map[string]string{
+				"component": "container runtime",
+				"id_prefix": "ACME_PLAT_CR",
+			},
+			wantErr:     true,
+			errContains: "must match",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			req := &mcp.GetPromptRequest{
+				Params: &mcp.GetPromptParams{
+					Name:      "mapping_document",
+					Arguments: tt.arguments,
+				},
+			}
+
+			result, err := handler(ctx, req)
+
+			if tt.wantErr {
+				require.Error(t, err)
+				if tt.errContains != "" {
+					assert.Contains(t, err.Error(), tt.errContains)
+				}
+				return
+			}
+
+			require.NoError(t, err)
+			require.NotNil(t, result)
+			if tt.validateResult != nil {
+				tt.validateResult(t, result)
+			}
+		})
+	}
+}
+
+func TestNewMappingDocumentHandlerLexiconFetchError(t *testing.T) {
+	handler := NewMappingDocumentHandler(failingLexiconFetcher, mockSchemaFetcher)
+	req := &mcp.GetPromptRequest{
+		Params: &mcp.GetPromptParams{
+			Name:      "mapping_document",
+			Arguments: map[string]string{"component": "test", "id_prefix": "ACME.TEST"},
+		},
+	}
+
+	_, err := handler(context.Background(), req)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "fetching lexicon")
+}
+
+func TestNewMappingDocumentHandlerSchemaFetchError(t *testing.T) {
+	handler := NewMappingDocumentHandler(mockLexiconFetcher, failingSchemaFetcher)
+	req := &mcp.GetPromptRequest{
+		Params: &mcp.GetPromptParams{
+			Name:      "mapping_document",
+			Arguments: map[string]string{"component": "test", "id_prefix": "ACME.TEST"},
+		},
+	}
+
+	_, err := handler(context.Background(), req)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "fetching schema docs")
+	assert.Contains(t, err.Error(), "network error")
+}
+
+func TestPromptMappingDocumentMetadata(t *testing.T) {
+	assert.Equal(t, "mapping_document", PromptMappingDocument.Name)
+	assert.NotEmpty(t, PromptMappingDocument.Description)
+	require.Len(t, PromptMappingDocument.Arguments, 2)
+
+	componentArg := PromptMappingDocument.Arguments[0]
+	assert.Equal(t, "component", componentArg.Name)
+	assert.True(t, componentArg.Required)
+
+	prefixArg := PromptMappingDocument.Arguments[1]
+	assert.Equal(t, "id_prefix", prefixArg.Name)
+	assert.True(t, prefixArg.Required)
+}
+
 func TestPromptThreatAssessmentMetadata(t *testing.T) {
 	assert.Equal(t, "threat_assessment", PromptThreatAssessment.Name)
 	assert.NotEmpty(t, PromptThreatAssessment.Description)


### PR DESCRIPTION
## Description

This PR adds a MappingDocument wizard to the set of assistants available for artifact authoring. Through prompting, the version of the gemara artifacts are identified and if `< v1.0.0` the user will be prompted to start with the migration wizard. 

If the user decides to move forward without migrating the artifacts, the mapping document wizard will find the equivalent fields based on the `gemara-version`. 

## Related Issues

- Closes Issue gemaraproj/gemara-ai#8 

## Review Hints

- Prompt for creation of a mapping document