### PR TITLE
ci: add NFR6 eval as post-release hook

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,3 +71,10 @@ jobs:
             --certificate-identity-regexp="${IDENTITY}" \
             --certificate-oidc-issuer="${OIDC_ISSUER}" \
             "${IMAGE}:latest" > /dev/null
+
+  nfr6-eval:
+    needs: goreleaser
+    uses: gemaraproj/gemara-mcp-eval-infra/.github/workflows/determinism-check.yml@ff4931370ed6b2b65556a489595adbf8306f1fa5 # pin to main — update SHA after eval-infra#2 merges
+    with:
+      gemara_mcp_image: "ghcr.io/gemaraproj/gemara-mcp:${{ github.ref_name }}"
+      gemara_schema_ref: "${{ github.ref_name }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,7 +74,7 @@ jobs:
 
   nfr6-eval:
     needs: goreleaser
-    uses: gemaraproj/gemara-mcp-eval-infra/.github/workflows/determinism-check.yml@ff4931370ed6b2b65556a489595adbf8306f1fa5 # pin to main — update SHA after eval-infra#2 merges
+    uses: gemaraproj/gemara-mcp-eval-infra/.github/workflows/determinism-check.yml@5b930c5c51da30998326384d196363734c84fc75 # pin to main — update SHA after eval-infra#3 merges
     with:
       gemara_mcp_image: "ghcr.io/gemaraproj/gemara-mcp:${{ github.ref_name }}"
       gemara_schema_ref: "${{ github.ref_name }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,7 +74,7 @@ jobs:
 
   nfr6-eval:
     needs: goreleaser
-    uses: gemaraproj/gemara-mcp-eval-infra/.github/workflows/determinism-check.yml@5b930c5c51da30998326384d196363734c84fc75 # pin to main — update SHA after eval-infra#3 merges
+    uses: gemaraproj/gemara-mcp-eval-infra/.github/workflows/determinism-check.yml@81013dcb4c86486b59d78b048db4a2d793d51119 # v0.1.0
     with:
       gemara_mcp_image: "ghcr.io/gemaraproj/gemara-mcp:${{ github.ref_name }}"
       gemara_schema_ref: "${{ github.ref_name }}"


### PR DESCRIPTION
## Summary

- Add an `nfr6-eval` job to the release workflow that calls `gemaraproj/gemara-mcp-eval-infra`'s `determinism-check.yml` via `workflow_call` after `goreleaser` publishes the image and verifies its signature.
- Passes the release tag (`github.ref_name`) as both `gemara_mcp_image` and `gemara_schema_ref`, so the eval runs against the exact build artifact with the matching schema version.

## Context

Per [#14](https://github.com/gemaraproj/gemara-mcp/issues/14) — Jenn confirmed the post-release hook is the completion criterion for closing the issue.

This depends on [gemaraproj/gemara-mcp-eval-infra#2](https://github.com/gemaraproj/gemara-mcp-eval-infra/pull/2) landing first (adds the `workflow_call` trigger to the eval workflow).

Closes #14

## Test plan

- [ ] Verify the release workflow YAML is valid (`act` or GitHub Actions lint)
- [ ] After eval-infra PR merges, trigger a test release to confirm the `nfr6-eval` job runs inline
- [ ] Confirm the eval job appears in the release workflow run and reports NFR6 pass/fail
