### PR TITLE
feat: use gemara.Lexicon from Go SDK for lexicon resource

### DIFF
--- a/internal/server/lexicon.yaml
+++ b/internal/server/lexicon.yaml
@@ -1,105 +1,249 @@
-- term: Assessment
-  definition: (1) the process of determining whether an outcome meets the actor's intent; or (2) an atomic process within an Evaluation used to determine a resource's Compliance with an Assessment Requirement
-  references: ["Layer 5"]
-- term: Assessment Requirement
-  definition: a tightly scoped, verifiable condition that must be satisfied and confirmed by an evaluator
-  references: ["Layer 2"]
-- term: Audit
-  definition: a formal, opinionated review of an organization's Policies and posture, conducted at a specific point in time to verify that established requirements are met
-  references: ["Layer 7"]
-- term: Behavior Evaluation
-  definition: an opinionated observation of simulated or real-world activities
-  references: ["Layer 5"]
-- term: Capability
-  definition: a feature or function of a system; the primary component comprising an attack surface
-  references: ["Layer 2"]
-- term: Catalog
-  definition: a structured set of related prose and relevant metadata
-  references: ["Layer 1", "Layer 2", "Layer 3"]
-- term: Continuous Monitoring
-  definition: a multi-system process designed to collect Evaluation and operational data on an ongoing basis to better detect malicious action and non-compliance, enable Remediative Enforcement, and observe trends over time
-  references: ["Layer 7"]
-- term: Control
-  definition: (1) an organization's ability to fully assert desired state on a system, resource, or state; or (2) a mechanism, such as a safeguard or countermeasure, that asserts desired state; or (3) prose describing the Objective and Assessment Requirements associated with a desired state
-  references: ["Layer 2"]
-- term: Compliance
-  definition: adherence to a Rule or set of Rules
-  references: []
-- term: Evaluation
-  definition: the manual or automated process of forming an opinion on the state of Compliance, guided by a set of Assessment Requirements
-  references: ["Layer 5"]
-- term: Enforcement
-  definition: an action taken in response to non-compliance findings and their causes
-  references: ["Layer 6"]
-- term: Evaluation Finding
-  definition: the evidence and opinionated result of an Assessment
-  references: ["Layer 5"]
-- term: Guidance
-  definition: prose intended to help bring about a desired outcome for a topic or generalized scenario, based on knowledge of relevant Vectors
-  references: ["Layer 1"]
-- term: Guideline
-  definition: atomic element of a Guidance Catalog; often includes explanatory context and recommendations for designing optimal implementations
-  references: ["Layer 1"]
-- term: GRC
-  definition: (1) the Governance, Risk, and Compliance domain within the cybersecurity field; or (2) a coordinated program dedicated to these elements within a business unit
-  references: []
-- term: Governance
-  definition: strategic oversight of an organization and its activities
-  references: []
-- term: Intent Evaluation
-  definition: an Evaluation ensuring that a resource is prepared in alignment with Policy, such as through proper training, configuration, or code
-  references: ["Layer 5"]
-- term: Organization
-  definition: any logical grouping of human, physical, virtual, and information resources such as a company, business unit, or team
-  references: ["Layer 3"]
-- term: Threat
-  definition: a circumstance or event where the concepts of a vector are applied to a Capability in a specific context, resulting in the potential for negative impact
-  references: ["Layer 2"]
-- term: Objective
-  definition: a unified statement of intent, which may encompass multiple situationally applicable statements or requirements
-  references: ["Layer 2"]
-- term: Opinion
-  definition: a firmly held approximation of reality formed within the constraints of an evaluator's philosophy, perspective, and capabilities
-  references: ["Layer 5", "Layer 6", "Layer 7"]
-- term: Policy
-  definition: a clearly-scoped set of rules based on an organization's Risk Appetite
-  references: ["Layer 3"]
-- term: Preventive Enforcement
-  definition: any action that interrupts another process which would otherwise cause non-compliance
-  references: ["Layer 6"]
-- term: Remediative Enforcement
-  definition: corrective action in response to non-compliance in a deployed activity
-  references: ["Layer 6"]
-- term: Residual Risk
-  definition: the Risk remaining after Risk Mitigation and Enforcement actions have been implemented
-  references: ["Layer 3"]
-- term: Risk
-  definition: the potential for loss or damage when a Threat is actualized, determined by calculating the impact of an event to an organization and the likelihood of its occurrence
-  references: ["Layer 3"]
-- term: Risk Catalog
-  definition: a group of related Risks relevant to an organization; used to determine when and how Policies are created for the organization
-  references: ["Layer 3"]
-- term: Risk Appetite
-  definition: the level of Risk an organization is willing to accept in pursuit of its objectives
-  references: ["Layer 3"]
-- term: Risk Assessment
-  definition: the process of identifying the potential or actual Risks introduced by a system
-  references: ["Layer 3"]
-- term: Risk Mitigation
-  definition: the process of developing actions to prevent Threats or reduce their impact on organization objectives
-  references: ["Layer 3"]
-- term: Risk Acceptance
-  definition: a clearly documented decision to accept an unmitigated Risk as necessary or unavoidable
-  references: ["Layer 3"]
-- term: Rule
-  definition: an active, enforceable Policy, regulation, or law
-  references: ["Layer 1", "Layer 2", "Layer 3"]
-- term: Sensitive Activity
-  definition: a type of action that introduces Risk to an organization
-  references: ["Layer 4"]
-- term: Vector
-  definition: (1) an opportunity for an attacker to exploit a vulnerability in the system; or (2) a path by which neglect could result in unintentional negative outcomes
-  references: ["Layer 1"]
-- term: Vulnerability
-  definition: (1) a weakness in a system inherent in or associated with a Capability that can be exploited when used in unintended ways; or (2) a lack of Control or gap in defense, introduced intentionally or unintentionally, which can be leveraged to cause harm
-  references: ["Layer 2", "Layer 4"]
+title: Gemara Lexicon
+metadata:
+  id: gemara-lexicon
+  type: Lexicon
+  gemara-version: "1.0.0"
+  description: Controlled vocabulary for the Gemara project
+  author:
+    id: gemara-maintainers
+    name: Gemara Maintainers
+    type: Human
+terms:
+  - id: assessment
+    title: Assessment
+    definition: >
+      (1) the process of determining whether an outcome meets the actor's intent;
+      or (2) an atomic process within an Evaluation used to determine a resource's
+      Compliance with an Assessment Requirement
+    references:
+      - citation: Layer 5
+  - id: assessment-requirement
+    title: Assessment Requirement
+    definition: >
+      a tightly scoped, verifiable condition that must be satisfied and confirmed
+      by an evaluator
+    references:
+      - citation: Layer 2
+  - id: audit
+    title: Audit
+    definition: >
+      a formal, opinionated review of an organization's Policies and posture,
+      conducted at a specific point in time to verify that established requirements
+      are met
+    references:
+      - citation: Layer 7
+  - id: behavior-evaluation
+    title: Behavior Evaluation
+    definition: an opinionated observation of simulated or real-world activities
+    references:
+      - citation: Layer 5
+  - id: capability
+    title: Capability
+    definition: >
+      a feature or function of a system; the primary component comprising an
+      attack surface
+    references:
+      - citation: Layer 2
+  - id: catalog
+    title: Catalog
+    definition: a structured set of related prose and relevant metadata
+    references:
+      - citation: Layer 1
+      - citation: Layer 2
+      - citation: Layer 3
+  - id: continuous-monitoring
+    title: Continuous Monitoring
+    definition: >
+      a multi-system process designed to collect Evaluation and operational data
+      on an ongoing basis to better detect malicious action and non-compliance,
+      enable Remediative Enforcement, and observe trends over time
+    references:
+      - citation: Layer 7
+  - id: control
+    title: Control
+    definition: >
+      (1) an organization's ability to fully assert desired state on a system,
+      resource, or state; or (2) a mechanism, such as a safeguard or
+      countermeasure, that asserts desired state; or (3) prose describing the
+      Objective and Assessment Requirements associated with a desired state
+    references:
+      - citation: Layer 2
+  - id: compliance
+    title: Compliance
+    definition: adherence to a Rule or set of Rules
+  - id: evaluation
+    title: Evaluation
+    definition: >
+      the manual or automated process of forming an opinion on the state of
+      Compliance, guided by a set of Assessment Requirements
+    references:
+      - citation: Layer 5
+  - id: enforcement
+    title: Enforcement
+    definition: >
+      an action taken in response to non-compliance findings and their causes
+    references:
+      - citation: Layer 6
+  - id: evaluation-finding
+    title: Evaluation Finding
+    definition: the evidence and opinionated result of an Assessment
+    references:
+      - citation: Layer 5
+  - id: guidance
+    title: Guidance
+    definition: >
+      prose intended to help bring about a desired outcome for a topic or
+      generalized scenario, based on knowledge of relevant Vectors
+    references:
+      - citation: Layer 1
+  - id: guideline
+    title: Guideline
+    definition: >
+      atomic element of a Guidance Catalog; often includes explanatory context
+      and recommendations for designing optimal implementations
+    references:
+      - citation: Layer 1
+  - id: grc
+    title: GRC
+    definition: >
+      (1) the Governance, Risk, and Compliance domain within the cybersecurity
+      field; or (2) a coordinated program dedicated to these elements within a
+      business unit
+  - id: governance
+    title: Governance
+    definition: strategic oversight of an organization and its activities
+  - id: intent-evaluation
+    title: Intent Evaluation
+    definition: >
+      an Evaluation ensuring that a resource is prepared in alignment with Policy,
+      such as through proper training, configuration, or code
+    references:
+      - citation: Layer 5
+  - id: organization
+    title: Organization
+    definition: >
+      any logical grouping of human, physical, virtual, and information resources
+      such as a company, business unit, or team
+    references:
+      - citation: Layer 3
+  - id: threat
+    title: Threat
+    definition: >
+      a circumstance or event where the concepts of a vector are applied to a
+      Capability in a specific context, resulting in the potential for negative
+      impact
+    references:
+      - citation: Layer 2
+  - id: objective
+    title: Objective
+    definition: >
+      a unified statement of intent, which may encompass multiple situationally
+      applicable statements or requirements
+    references:
+      - citation: Layer 2
+  - id: opinion
+    title: Opinion
+    definition: >
+      a firmly held approximation of reality formed within the constraints of an
+      evaluator's philosophy, perspective, and capabilities
+    references:
+      - citation: Layer 5
+      - citation: Layer 6
+      - citation: Layer 7
+  - id: policy
+    title: Policy
+    definition: a clearly-scoped set of rules based on an organization's Risk Appetite
+    references:
+      - citation: Layer 3
+  - id: preventive-enforcement
+    title: Preventive Enforcement
+    definition: >
+      any action that interrupts another process which would otherwise cause
+      non-compliance
+    references:
+      - citation: Layer 6
+  - id: remediative-enforcement
+    title: Remediative Enforcement
+    definition: corrective action in response to non-compliance in a deployed activity
+    references:
+      - citation: Layer 6
+  - id: residual-risk
+    title: Residual Risk
+    definition: >
+      the Risk remaining after Risk Mitigation and Enforcement actions have been
+      implemented
+    references:
+      - citation: Layer 3
+  - id: risk
+    title: Risk
+    definition: >
+      the potential for loss or damage when a Threat is actualized, determined by
+      calculating the impact of an event to an organization and the likelihood of
+      its occurrence
+    references:
+      - citation: Layer 3
+  - id: risk-catalog
+    title: Risk Catalog
+    definition: >
+      a group of related Risks relevant to an organization; used to determine
+      when and how Policies are created for the organization
+    references:
+      - citation: Layer 3
+  - id: risk-appetite
+    title: Risk Appetite
+    definition: >
+      the level of Risk an organization is willing to accept in pursuit of its
+      objectives
+    references:
+      - citation: Layer 3
+  - id: risk-assessment
+    title: Risk Assessment
+    definition: >
+      the process of identifying the potential or actual Risks introduced by a
+      system
+    references:
+      - citation: Layer 3
+  - id: risk-mitigation
+    title: Risk Mitigation
+    definition: >
+      the process of developing actions to prevent Threats or reduce their impact
+      on organization objectives
+    references:
+      - citation: Layer 3
+  - id: risk-acceptance
+    title: Risk Acceptance
+    definition: >
+      a clearly documented decision to accept an unmitigated Risk as necessary or
+      unavoidable
+    references:
+      - citation: Layer 3
+  - id: rule
+    title: Rule
+    definition: an active, enforceable Policy, regulation, or law
+    references:
+      - citation: Layer 1
+      - citation: Layer 2
+      - citation: Layer 3
+  - id: sensitive-activity
+    title: Sensitive Activity
+    definition: a type of action that introduces Risk to an organization
+    references:
+      - citation: Layer 4
+  - id: vector
+    title: Vector
+    definition: >
+      (1) an opportunity for an attacker to exploit a vulnerability in the system;
+      or (2) a path by which neglect could result in unintentional negative
+      outcomes
+    references:
+      - citation: Layer 1
+  - id: vulnerability
+    title: Vulnerability
+    definition: >
+      (1) a weakness in a system inherent in or associated with a Capability that
+      can be exploited when used in unintended ways; or (2) a lack of Control or
+      gap in defense, introduced intentionally or unintentionally, which can be
+      leveraged to cause harm
+    references:
+      - citation: Layer 2
+      - citation: Layer 4

--- a/internal/server/mode.go
+++ b/internal/server/mode.go
@@ -42,6 +42,10 @@ type AdvisoryMode struct {
 
 // NewAdvisoryMode creates a new AdvisoryMode with the provided cache TTL.
 func NewAdvisoryMode(cacheTTL time.Duration) (*AdvisoryMode, error) {
+	if _, err := parseLexicon([]byte(EmbeddedLexicon)); err != nil {
+		return nil, fmt.Errorf("embedded lexicon is invalid: %w", err)
+	}
+
 	lexiconBuilder, err := fetcher.NewURLBuilder(lexiconBaseURL, lexiconPathSuffix)
 	if err != nil {
 		return nil, fmt.Errorf("creating lexicon URL builder: %w", err)

--- a/internal/server/resources.go
+++ b/internal/server/resources.go
@@ -10,6 +10,9 @@ import (
 	"net/url"
 
 	"cuelang.org/go/cue"
+	gemara "github.com/gemaraproj/go-gemara"
+	goyaml "github.com/goccy/go-yaml"
+
 	"github.com/gemaraproj/gemara-mcp/internal/server/fetcher"
 	"github.com/gemaraproj/gemara-mcp/internal/server/schema"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
@@ -54,6 +57,23 @@ func (a *AdvisoryMode) handleLexiconResource(ctx context.Context, req *mcp.ReadR
 	}, nil
 }
 
+// parseLexicon validates YAML content against the gemara.Lexicon type from
+// the SDK. Uses goccy/go-yaml directly because the SDK's codec package is
+// internal and gemara.Load assumes a file/URL fetch workflow.
+func parseLexicon(data []byte) (*gemara.Lexicon, error) {
+	var lex gemara.Lexicon
+	if err := goyaml.Unmarshal(data, &lex); err != nil {
+		return nil, fmt.Errorf("unmarshalling lexicon: %w", err)
+	}
+	if lex.Title == "" {
+		return nil, fmt.Errorf("lexicon missing required field: title")
+	}
+	if len(lex.Terms) == 0 {
+		return nil, fmt.Errorf("lexicon contains no terms")
+	}
+	return &lex, nil
+}
+
 // fetchLexicon retrieves the lexicon from the remote URL, falling back to
 // the embedded copy on failure.
 func (a *AdvisoryMode) fetchLexicon(ctx context.Context) (content string, source string) {
@@ -73,6 +93,11 @@ func (a *AdvisoryMode) fetchLexicon(ctx context.Context) (content string, source
 	data, src, err := cf.Fetch(ctx, false)
 	if err != nil {
 		slog.Warn("failed to fetch lexicon, using embedded fallback", "error", err)
+		return EmbeddedLexicon, "embedded"
+	}
+
+	if _, err := parseLexicon(data); err != nil {
+		slog.Warn("remote lexicon failed validation, using embedded fallback", "error", err)
 		return EmbeddedLexicon, "embedded"
 	}
 

--- a/internal/server/resources_integration_test.go
+++ b/internal/server/resources_integration_test.go
@@ -39,7 +39,7 @@ func TestReadLexiconResource(t *testing.T) {
 	content := result.Contents[0]
 	assert.Equal(t, LexiconResourceURI, content.URI)
 	assert.Equal(t, "text/yaml", content.MIMEType)
-	assert.Contains(t, content.Text, "term:")
+	assert.Contains(t, content.Text, "title:")
 }
 
 func TestReadLexiconResourceReturnsContent(t *testing.T) {
@@ -121,5 +121,5 @@ func TestArtifactModeResourceAccess(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.Len(t, result.Contents, 1)
-	assert.Contains(t, result.Contents[0].Text, "term:")
+	assert.Contains(t, result.Contents[0].Text, "title:")
 }

--- a/internal/server/resources_test.go
+++ b/internal/server/resources_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -29,4 +30,89 @@ func TestReadSchemaDocsTemplateResourceInvalidVersion(t *testing.T) {
 		URI: "gemara://schema/definitions?version=not-semver",
 	})
 	require.Error(t, err)
+}
+
+func TestParseLexicon(t *testing.T) {
+	tests := []struct {
+		name        string
+		input       string
+		wantErr     bool
+		errContains string
+	}{
+		{
+			name:  "valid lexicon",
+			input: EmbeddedLexicon,
+		},
+		{
+			name:        "invalid YAML",
+			input:       "not: [valid: yaml",
+			wantErr:     true,
+			errContains: "unmarshalling",
+		},
+		{
+			name: "missing title",
+			input: `metadata:
+  id: test
+  type: Lexicon
+  gemara-version: "1.0.0"
+  description: test
+  author:
+    id: test
+    name: Test
+    type: Human
+terms:
+  - id: t1
+    title: Term
+    definition: def`,
+			wantErr:     true,
+			errContains: "title",
+		},
+		{
+			name: "empty terms",
+			input: `title: Test Lexicon
+metadata:
+  id: test
+  type: Lexicon
+  gemara-version: "1.0.0"
+  description: test
+  author:
+    id: test
+    name: Test
+    type: Human
+terms: []`,
+			wantErr:     true,
+			errContains: "no terms",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			lex, err := parseLexicon([]byte(tt.input))
+			if tt.wantErr {
+				require.Error(t, err)
+				if tt.errContains != "" {
+					assert.Contains(t, err.Error(), tt.errContains)
+				}
+				return
+			}
+			require.NoError(t, err)
+			assert.NotEmpty(t, lex.Title)
+			assert.NotEmpty(t, lex.Terms)
+		})
+	}
+}
+
+func TestEmbeddedLexiconConformsToSDKType(t *testing.T) {
+	lex, err := parseLexicon([]byte(EmbeddedLexicon))
+	require.NoError(t, err)
+
+	assert.Equal(t, "Gemara Lexicon", lex.Title)
+	assert.Equal(t, "gemara-lexicon", lex.Metadata.Id)
+	assert.Greater(t, len(lex.Terms), 0)
+
+	for _, term := range lex.Terms {
+		assert.NotEmpty(t, term.Id, "term missing id")
+		assert.NotEmpty(t, term.Title, "term %s missing title", term.Id)
+		assert.NotEmpty(t, term.Definition, "term %s missing definition", term.Id)
+	}
 }


### PR DESCRIPTION
Replace the ad-hoc lexicon.yaml format with the official gemara.Lexicon schema structure. Parse and validate lexicon content using the SDK type at startup and on remote fetch, falling back to the embedded copy when validation fails.

Closes #61