### PR TITLE
chore: bumps gemara version to v1.2.0

### DIFF
--- a/.github/capabilities.yaml
+++ b/.github/capabilities.yaml
@@ -3,7 +3,7 @@ title: Gemara MCP Server Security Capability Catalog
 metadata:
   id: GEMARAPROJ.GEMARA.MCP
   type: CapabilityCatalog
-  gemara-version: "v1.0.0"
+  gemara-version: "v1.2.0"
   version: 1.0.0
   description: >-
     The Gemara MCP Server exposes tools to help with Gemara artifact authoring.

--- a/.github/controls.yaml
+++ b/.github/controls.yaml
@@ -3,7 +3,7 @@ title: Gemara MCP Server Security Control Catalog
 metadata:
   id: GEMARAPROJ.GEMARA.MCP
   type: ControlCatalog
-  gemara-version: "v1.0.0"
+  gemara-version: "v1.2.0"
   version: 1.0.0
   description: >-
     The Gemara MCP Server exposes tools to help with Gemara artifact authoring.

--- a/.github/threats.yaml
+++ b/.github/threats.yaml
@@ -3,7 +3,7 @@ title: Gemara MCP Server Security Threat Catalog
 metadata:
   id: GEMARAPROJ.GEMARA.MCP
   type: ThreatCatalog
-  gemara-version: "v1.0.0"
+  gemara-version: "v1.2.0"
   version: 1.0.0
   description: >-
     The Gemara MCP Server exposes tools to help with Gemara artifact authoring.


### PR DESCRIPTION
## Description

This PR updates the testdata in `.github/` to the latest minor release of the schemas (`v1.2.0`). This ensures consistency with the schemas. 