### PR TITLE
fix: disable GoReleaser release to align with reusable workflow

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -61,4 +61,4 @@ changelog:
       - "^test:"
 
 release:
-  prerelease: auto
+  disable: true


### PR DESCRIPTION
The ospo-reusable-workflows release job manages the GitHub release lifecycle and requires GoReleaser to not publish its own release.

Assisted-by: Cursor (claude-opus-4-0526)