### PR TITLE
ci: align release workflow with reusable workflow Docker pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,9 @@ permissions:
 
 jobs:
   release:
+    if: >
+      github.event_name == 'workflow_dispatch' ||
+      github.event.pull_request.merged == true
     permissions:
       contents: write       # Create release and push tags
       pull-requests: read   # Read PR labels for release-drafter
@@ -24,13 +27,16 @@ jobs:
       release-config-name: release-drafter.yml
       goreleaser-config-path: .goreleaser.yaml
       go-version-file: go.mod
+      image-name: gemaraproj/gemara-mcp
       create-attestation: true
     secrets:
       github-token: ${{ secrets.GITHUB_TOKEN }}
+      image-registry-password: ${{ secrets.GITHUB_TOKEN }}
 
   nfr6-eval:
     needs: release
+    if: ${{ needs.release.outputs.full-tag != '' }}
     uses: gemaraproj/gemara-mcp-eval-infra/.github/workflows/determinism-check.yml@81013dcb4c86486b59d78b048db4a2d793d51119 # v0.1.0
     with:
-      gemara_mcp_image: "ghcr.io/gemaraproj/gemara-mcp:${{ github.ref_name }}"
-      gemara_schema_ref: "${{ github.ref_name }}"
+      gemara_mcp_image: "ghcr.io/gemaraproj/gemara-mcp:${{ needs.release.outputs.full-tag }}"
+      gemara_schema_ref: "${{ needs.release.outputs.full-tag }}"

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,5 +1,12 @@
 # yaml-language-server: $schema=https://goreleaser.com/static/schema.json
 # vim: set ts=2 sw=2 tw=0 fo=cnqoj
+#
+# NOTE: GoReleaser handles binary builds and archives only.
+# Docker image build/push and SLSA provenance attestation are managed by the
+# ospo-reusable-workflows release workflow (see .github/workflows/release.yml).
+# Container image signing is provided via actions/attest-build-provenance
+# (Sigstore-backed SLSA attestation pushed to the registry) rather than
+# standalone cosign signatures.
 
 version: 2
 
@@ -33,25 +40,8 @@ archives:
       {{- else }}{{ .Arch }}{{ end }}
       {{- if .Arm }}v{{ .Arm }}{{ end }}
 
-dockers_v2:
-  - images:
-      - "ghcr.io/gemaraproj/gemara-mcp"
-    dockerfile: Dockerfile.goreleaser
-    tags:
-      - "{{ .Version }}"
-      - latest
-    platforms:
-      - linux/amd64
-      - linux/arm64
-
-# signs our docker image
-docker_signs:
-  - cmd: cosign
-    output: true
-    args:
-      - "sign"
-      - "${artifact}@${digest}"
-      - "--yes"
+checksum:
+  name_template: "checksums.txt"
 
 changelog:
   sort: asc


### PR DESCRIPTION
The release workflow was failing because GoReleaser's dockers_v2 and docker_signs sections require Docker buildx, QEMU, registry auth, and cosign — none of which are available in the reusable workflow's release_goreleaser job.

Changes:
- Remove dockers_v2 and docker_signs from .goreleaser.yaml; GoReleaser now handles only binary builds and archives
- Add image-name input to activate the reusable workflow's release_image job for Docker image build/push via docker/build-push-action
- Add image-registry-password secret for GHCR authentication
- Add merge guard (merged == true) to prevent closed-but-unmerged PRs from triggering the release pipeline with elevated permissions
- Use release job output (full-tag) instead of github.ref_name for nfr6-eval to ensure correct image tag resolution
- Document the separation of concerns between GoReleaser and the reusable workflow, including the shift from cosign signatures to SLSA provenance attestation via actions/attest-build-provenance