### PR TITLE
fix: update golangci-lint pinned tag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
           go-version-file: go.mod
 
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a #v8.0.0
+        uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0
         with:
           version: v2.4.0
 


### PR DESCRIPTION
## Description
This PR rebases the golangci/golangci-lint action that was incorrectly pinned to `#v8.0.0` when the SHA and dependabot update was for golangci/golangci-lint `# v9.3.0`. The DCO requirement prompted a rebase.

## Related Issues

- https://github.com/gemaraproj/gemara-mcp/pull/95
