### PR TITLE
fix(prompts): guide users to omit url for bundle-local mapping-references

### DIFF
--- a/internal/server/prompts/control_catalog_system.md
+++ b/internal/server/prompts/control_catalog_system.md
@@ -46,7 +46,11 @@ Execution steps:
       Reply with letters (e.g., "a, d") or specify your own framework.
 
    - Add a `mapping-references` entry for each selected framework.
-   - Generate the metadata YAML block:
+   - Generate the metadata YAML block.
+
+   **URL rules for `mapping-references`:**
+   - **Bundle-local** references (artifacts that live in the same repository/bundle and will be assembled together) SHOULD omit `url`. The assembler resolves these by matching `mapping-reference.id` against `metadata.id` of peer artifacts in the bundle.
+   - **External** references (public frameworks, upstream catalogs hosted at a URL) SHOULD include `url`.
 
    ```yaml
    metadata:
@@ -63,7 +67,7 @@ Execution steps:
        - id: {from step 1}
          title: {from step 1}
          version: {from step 1}
-         url: {from step 1}
+         url: {from step 1, only if external}
          description: {from step 1}
        - id: {framework id}
          title: {framework title}

--- a/internal/server/prompts/threat_assessment_system.md
+++ b/internal/server/prompts/threat_assessment_system.md
@@ -34,6 +34,10 @@ Execution steps:
    2. Author name and identifier.
    3. Confirmation of the generated metadata before proceeding.
 
+   **URL rules for `mapping-references`:**
+   - **Bundle-local** references (artifacts that live in the same repository/bundle and will be assembled together) SHOULD omit `url`. The assembler resolves these by matching `mapping-reference.id` against `metadata.id` of peer artifacts in the bundle.
+   - **External** references (public frameworks, upstream catalogs hosted at a URL) SHOULD include `url`.
+
    ```yaml
    metadata:
      id: ${ID_PREFIX}
@@ -49,7 +53,7 @@ Execution steps:
        - id: {from step 1}
          title: {from step 1}
          version: {from step 1}
-         url: {from step 1}
+         url: {from step 1, only if external}
          description: {from step 1}
    title: ${COMPONENT} Security Threat Catalog
    ```


### PR DESCRIPTION
## Summary

Adds explicit URL guidance to the control catalog and threat assessment wizard system prompts: bundle-local references SHOULD omit `url`; external references SHOULD include `url`.

When referenced artifacts live in the same bundle, the assembler resolves by matching `mapping-reference.id` against `metadata.id` of peer artifacts — no `file://` fetch needed. Generating `file://` URLs for bundle-local refs is fragile because `grc` resolves relative paths against the process working directory, which varies by caller (see gemaraproj/go-gemara#93).

## Changes

- `control_catalog_system.md` — added "URL rules for mapping-references" block, changed template `url` field to indicate "only if external"
- `threat_assessment_system.md` — same

## Follow-up
- Apply same URL rules to policy wizard when gemaraproj/gemara-ai#10 is implemented

## Related

- Closes gemaraproj/gemara-mcp#101
- gemaraproj/go-gemara#93 — fetcher resolves relative `file://` URLs relative to working directory, not source artifact
- complytime-labs UAT failure caused by this behavior