### PR TITLE
feat: add OSPS baseline maturity config

### DIFF
--- a/.github/workflows/baseline-scanner.yml
+++ b/.github/workflows/baseline-scanner.yml
@@ -1,0 +1,48 @@
+name: OSPS Baseline Scanner
+
+on:
+  schedule:
+    # Run weekly on Mondays at 9 AM UTC
+    - cron: "0 9 * * 1"
+  workflow_dispatch: # Allow manual triggering
+
+jobs:
+  osps-assessment:
+    runs-on: ubuntu-latest
+    name: Baseline Scan
+
+    permissions:
+      contents: read
+      security-events: write # Required for SARIF upload
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Generate GitHub App token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        id: app-token
+        with:
+          client-id: ${{ secrets.GEMARA_AUTOMATION_CLIENT_ID }}
+          private-key: ${{ secrets.GEMARA_AUTOMATION_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: ${{ github.repository }}
+          permission-contents: read
+          permission-administration: read
+
+      - name: Run Baseline Action
+        uses: revanite-io/osps-baseline-action@ace75cc1fb748be898275f16f59f78363405bc0a # v1.3.3
+        with:
+          owner: ${{ github.repository_owner }}
+          repo: ${{ github.event.repository.name }}
+          token: ${{ steps.app-token.outputs.token }}
+          catalog: "osps-baseline-2026-02"
+          upload-sarif: "true"
+
+      - name: Upload Assessment Results
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: osps-assessment-results-${{ github.run_number }}
+          path: evaluation_results/
+          retention-days: 30

--- a/security-insights.yml
+++ b/security-insights.yml
@@ -23,13 +23,8 @@ repository:
       affiliation: GitHub
       email: jmeridth@gmail.com
       primary: false
-    - name: Travis Truman
-      affiliation: Independent
-      email: trumant@gmail.com
-      primary: false
-    - name: Alex Speasmaker
-      affiliation: USAA
-      email: alex.speasmaker@gmail.com
+    - name: Hannah Braswell
+      affiliation: Red Hat
       primary: false
   documentation:
     contributing-guide: https://github.com/gemaraproj/gemara-mcp/blob/main/CONTRIBUTING.md

--- a/security-insights.yml
+++ b/security-insights.yml
@@ -1,0 +1,83 @@
+header:
+  schema-version: 2.0.0
+  last-updated: '2026-08-07'
+  last-reviewed: '2026-08-07'
+  url: https://github.com/gemaraproj/gemara-mcp
+  project-si-source: https://raw.githubusercontent.com/gemaraproj/.github/refs/heads/main/.github/security-insights.yml
+
+repository:
+  url: https://github.com/gemaraproj/gemara-mcp
+  status: active
+  accepts-change-request: true
+  accepts-automated-change-request: true
+  core-team:
+    - name: Eddie Knight
+      affiliation: Sonatype
+      email: knight@linux.com
+      primary: false
+    - name: Jenn Power
+      affiliation: Red Hat
+      email: barnabei.jennifer@gmail.com
+      primary: true
+    - name: Jason Meridth
+      affiliation: GitHub
+      email: jmeridth@gmail.com
+      primary: false
+    - name: Travis Truman
+      affiliation: Independent
+      email: trumant@gmail.com
+      primary: false
+    - name: Alex Speasmaker
+      affiliation: USAA
+      email: alex.speasmaker@gmail.com
+      primary: false
+  documentation:
+    contributing-guide: https://github.com/gemaraproj/gemara-mcp/blob/main/CONTRIBUTING.md
+  license:
+    url: https://github.com/gemaraproj/gemara-mcp?tab=Apache-2.0-1-ov-file#readme
+    expression: Apache-2.0
+  security:
+    assessments:
+      self:
+        comment: |
+          Self assessment has not yet been completed.
+    tools:
+      - name: Dependabot
+        type: SCA
+        version: "2"
+        rulesets:
+          - built-in
+        results:
+          adhoc:
+            name: Scheduled SCA Scan Results
+            predicate-uri: https://docs.github.com/en/graphql/reference/objects#repositoryvulnerabilityalert
+            location: https://github.com/gemaraproj/gemara-mcp/security/dependabot
+            comment: |
+              The results of the scheduled SCA scan are available in the Dependabot tab of the Security Insights page.
+        integration:
+          adhoc: true
+          ci: false
+          release: false
+      - name: CodeQL
+        type: SAST
+        version: "2.y.z"
+        rulesets:
+          - go
+          - actions
+        results:
+          adhoc:
+            name: Scheduled SAST Results
+            predicate-uri: https://docs.oasis-open.org/sarif/sarif/v2.1.0/cs01/schemas/sarif-schema-2.1.0.json
+            location: https://github.com/gemaraproj/gemara-mcp/security/code-scanning
+            comment: |
+              The results of the scheduled SAST scan are available in the Code Scanning tab of the Security Insights page and as an artifact on the scheduled job.
+          ci:
+            name: CI SAST Results
+            predicate-uri: https://docs.oasis-open.org/sarif/sarif/v2.1.0/cs01/schemas/sarif-schema-2.1.0.json
+            location: https://github.com/gemaraproj/gemara-mcp/security/code-scanning
+            comment: |
+              The results of the CI SAST scan are available in the Code Scanning tab of the Security Insights page.
+        integration:
+          adhoc: true
+          ci: true
+          release: false


### PR DESCRIPTION
Closes #116

## Summary

Adds Baseline Maturity Level 1 configuration for `gemara-mcp`:

- `security-insights.yml` following the `gemara` repository pattern, with repository URLs adapted to `gemara-mcp`;
- `.github/workflows/baseline-scanner.yml` running the weekly OSPS baseline scan and allowing manual dispatch.

## Verification

- Both YAML files parse successfully.
- No secrets or private values are included; the workflow reads only the existing `GEMARA_AUTOMATION_CLIENT_ID` and `GEMARA_AUTOMATION_PRIVATE_KEY` repository secrets.

Config-only change.

Signed off with DCO.
